### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/src/onecontainer_api/async_queue/Dockerfile
+++ b/src/onecontainer_api/async_queue/Dockerfile
@@ -3,6 +3,6 @@ FROM python:slim
 WORKDIR /workspace
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . ./

--- a/src/onecontainer_api/async_queue/tests/service_stub/Dockerfile
+++ b/src/onecontainer_api/async_queue/tests/service_stub/Dockerfile
@@ -2,7 +2,7 @@ FROM python:slim
 
 WORKDIR /workspace
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY service.py service.py
 
 ENTRYPOINT [ "python3" ]

--- a/src/onecontainer_api/backends/dlrs-pytorch-torchub/Dockerfile
+++ b/src/onecontainer_api/backends/dlrs-pytorch-torchub/Dockerfile
@@ -2,7 +2,7 @@ FROM sysstacks/dlrs-pytorch-ubuntu:latest
 
 WORKDIR /hub_server/
 COPY requirements.txt .
-RUN pip install -U -r requirements.txt
+RUN pip install --no-cache-dir -U -r requirements.txt
 COPY . /hub_server/
 ENTRYPOINT ["python"]
 CMD ["runner.py"]

--- a/src/onecontainer_api/backends/dlrs-pytorch/classifier/Dockerfile
+++ b/src/onecontainer_api/backends/dlrs-pytorch/classifier/Dockerfile
@@ -2,7 +2,7 @@ FROM sysstacks/dlrs-pytorch-ubuntu:latest
 
 WORKDIR /classifier/
 COPY requirements.txt .
-RUN pip install -U -r requirements.txt
+RUN pip install --no-cache-dir -U -r requirements.txt
 COPY . /classifier/
 ENTRYPOINT ["hypercorn","-kuvloop", "-b0.0.0.0:5059", "--debug", "-w1", "--reload"]
 CMD ["rest:app"]

--- a/src/onecontainer_api/drivers/dlrs-pytorch-minimal-0_1_0/Dockerfile
+++ b/src/onecontainer_api/drivers/dlrs-pytorch-minimal-0_1_0/Dockerfile
@@ -2,9 +2,9 @@ FROM python:slim
 
 WORKDIR /workspace
 
-RUN pip install pip --upgrade
+RUN pip install --no-cache-dir pip --upgrade
 COPY requirements.txt .
-RUN pip install -U  -r requirements.txt
+RUN pip install --no-cache-dir -U -r requirements.txt
 COPY . .
 
 #ENTRYPOINT [ "python", "./client.py" ]

--- a/src/onecontainer_api/drivers/dlrs-torchub-driver-0_1_0/Dockerfile
+++ b/src/onecontainer_api/drivers/dlrs-torchub-driver-0_1_0/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim-buster
 WORKDIR /workspace
 
 COPY requirements.txt .
-RUN pip --use-feature=2020-resolver install -U  -r requirements.txt
+RUN pip --use-feature=2020-resolver install --no-cache-dir -U  -r requirements.txt
 COPY . .
 
 EXPOSE 5055

--- a/templates/ai_driver/Dockerfile
+++ b/templates/ai_driver/Dockerfile
@@ -2,9 +2,9 @@ FROM python:slim
 
 WORKDIR /workspace
 
-RUN pip install pip --upgrade
+RUN pip install --no-cache-dir pip --upgrade
 COPY requirements.txt .
-RUN pip install -U  -r requirements.txt
+RUN pip install --no-cache-dir -U -r requirements.txt
 COPY . .
 
 EXPOSE 5055


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>